### PR TITLE
[feat] Allow to pass CI options for --ci-generate

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -946,6 +946,20 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :default: :class:`True`
     build_locally = variable(typ.Bool, value=True, loggable=True)
 
+    #: .. versionadded:: ??
+    #:
+    #: Options for CI pipeline passed in JSON format
+    #:
+    #: Example: If we want a pipeline to run only when files in 
+    #: backend or src/main.c have changed, we add:
+    #:
+    #: ci_options = {"only": {"changes": ["backend/*", "src/main.c"]}}
+    #: 
+    #: :type: `dict`
+    #: :default: ``{}``
+    ci_options = variable(typ.Dict[str, object],
+                          value={}, loggable=True)
+
     def __new__(cls, *args, **kwargs):
         obj = super().__new__(cls)
 

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -62,13 +62,15 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
         json['image'] = image_name
 
     for tc in testcases:
+        print("options", tc.check.ci_options)
         json[f'{tc.check.unique_name}'] = {
             'stage': f'rfm-stage-{tc.level}',
             'script': [rfm_command(tc)],
             'artifacts': {
                 'paths': [f'{tc.check.unique_name}-report.json']
             },
-            'needs': [t.check.unique_name for t in tc.deps]
+            'needs': [t.check.unique_name for t in tc.deps],
+            **tc.check.ci_options
         }
         max_level = max(max_level, tc.level)
 


### PR DESCRIPTION
This PR allows to pass arbitrary CI options for tests. Example: A test with option

```ci_options = {"only": {"changes": ["backend/*", "src/main.c"]}}```

will run only when files in `backend/` or `src/main.c` changes.